### PR TITLE
add comment

### DIFF
--- a/gap/BMod.gi
+++ b/gap/BMod.gi
@@ -179,7 +179,8 @@ end );
 InstallMethod( CategoryWithBialgebraAction,
         "for a CAP category and a list",
         [ IsCapCategory, IsList ],
-        
+
+  ## constructor for the category of modules with bialgebra action
   function( abelian_category, bialgebra )
     local category_with_bialgebra_action, number_of_generators_of_bialgebra,
           preconditions, category_weight_list, structure_record;


### PR DESCRIPTION
A line containing whiltespaces was replaced by an empty line. Is there a convention for the number of whitespaces on lines that contain nothing but whitespaces, possibly in function of the lines above and below it?